### PR TITLE
feat: Allow a delpy before and after message is send

### DIFF
--- a/beabee-client/src/deps.ts
+++ b/beabee-client/src/deps.ts
@@ -1,5 +1,4 @@
 export type {
-  CalloutFormSchema,
   CalloutResponseAnswer,
   CalloutResponseAnswerAddress,
   CalloutResponseAnswerFileUpload,
@@ -7,6 +6,7 @@ export type {
   CalloutResponseAnswersSlide,
   ContributionPeriod,
   ContributionType,
+  GetCalloutFormSchema,
   ItemStatus,
   MembershipStatus,
   NewsletterStatus,
@@ -16,5 +16,6 @@ export type {
   PaymentStatus,
   RoleType,
   RuleGroup,
+  SetCalloutFormSchema,
   StripeFeeCountry,
 } from "@beabee/beabee-common";

--- a/beabee-client/src/types/callout-form-data.ts
+++ b/beabee-client/src/types/callout-form-data.ts
@@ -1,7 +1,7 @@
-import type { CalloutFormSchema } from "../deps.ts";
+import type { GetCalloutFormSchema } from "../deps.ts";
 
 export interface CalloutFormData {
-  formSchema: CalloutFormSchema;
+  formSchema: GetCalloutFormSchema;
   intro: string;
   thanksText: string;
   thanksTitle: string;

--- a/telegram-bot/renderer/callout-response.renderer.ts
+++ b/telegram-bot/renderer/callout-response.renderer.ts
@@ -9,7 +9,7 @@ import {
   CalloutComponentNestableSchema,
   CalloutComponentSchema,
   CalloutComponentType,
-  CalloutSlideSchema,
+  GetCalloutSlideSchema,
   isCalloutComponentOfBaseType,
   isCalloutComponentOfType,
   Singleton,
@@ -731,7 +731,7 @@ export class CalloutResponseRenderer {
    * @param prefix The prefix, used to group the answers later (only used for slides)
    */
   public nestableComponent(
-    nestable: CalloutComponentNestableSchema | CalloutSlideSchema,
+    nestable: CalloutComponentNestableSchema | GetCalloutSlideSchema,
     prefix: string,
   ) {
     const nestableResults: Render[] = [];
@@ -858,6 +858,7 @@ export class CalloutResponseRenderer {
       html: ``,
       parseType: ParsedResponseType.NONE,
       removeKeyboard: true,
+      afterDelay: 3000,
     };
 
     if (callout.thanksTitle) {

--- a/telegram-bot/services/communication.service.ts
+++ b/telegram-bot/services/communication.service.ts
@@ -5,7 +5,7 @@ import { EventService } from "./event.service.ts";
 import { TransformService } from "./transform.service.ts";
 import { ConditionService } from "./condition.service.ts";
 import { ValidationService } from "./validation.service.ts";
-import { getIdentifier } from "../utils/index.ts";
+import { getIdentifier, sleep } from "../utils/index.ts";
 import { MessageRenderer } from "../renderer/message.renderer.ts";
 
 import type {
@@ -15,7 +15,7 @@ import type {
   RenderResponseParsed,
   ReplayAccepted,
 } from "../types/index.ts";
-import { InlineKeyboard, LinkPreviewOptions } from "../deps/grammy.ts";
+import { InlineKeyboard } from "../deps/grammy.ts";
 
 /**
  * Service to handle the communication with the telegram bot and the telegram user.
@@ -47,15 +47,16 @@ export class CommunicationService extends BaseService {
       throw new Error("You can only use one keyboard at a time");
     }
 
-    // Always resize the custom keyboard and all custom keyboards are one time keyboards the way we use them
-    if (render.keyboard) {
-      render.keyboard.oneTime().resized();
+    if (render.beforeDelay) {
+      await sleep(render.beforeDelay);
     }
 
-    // TODO: Make this configurable, link previews are disabled by default
-    const link_preview_options: LinkPreviewOptions = {
-      is_disabled: true,
-    };
+    // link previews are disabled by default
+    if (!render.linkPreview) {
+      render.linkPreview = {
+        is_disabled: true,
+      };
+    }
 
     const markup = render.keyboard || render.inlineKeyboard ||
       (render.removeKeyboard ? { remove_keyboard: true as true } : undefined);
@@ -67,7 +68,7 @@ export class CommunicationService extends BaseService {
         await ctx.replyWithMediaGroup([render.photo], {});
         if (render.keyboard) {
           message = await ctx.reply("", {
-            link_preview_options,
+            link_preview_options: render.linkPreview,
             reply_markup: markup,
           });
         }
@@ -75,20 +76,20 @@ export class CommunicationService extends BaseService {
       case RenderType.MARKDOWN:
         message = await ctx.reply(render.markdown, {
           parse_mode: "MarkdownV2",
-          link_preview_options,
+          link_preview_options: render.linkPreview,
           reply_markup: markup,
         });
         break;
       case RenderType.HTML:
         message = await ctx.reply(render.html, {
           parse_mode: "HTML",
-          link_preview_options,
+          link_preview_options: render.linkPreview,
           reply_markup: markup,
         });
         break;
       case RenderType.TEXT:
         message = await ctx.reply(render.text, {
-          link_preview_options,
+          link_preview_options: render.linkPreview,
           reply_markup: markup,
         });
         break;
@@ -97,7 +98,7 @@ export class CommunicationService extends BaseService {
         message = await (ctx as ParseModeFlavor<AppContext>).replyFmt(
           fmt(render.format),
           {
-            link_preview_options,
+            link_preview_options: render.linkPreview,
             reply_markup: markup,
           },
         );
@@ -122,6 +123,10 @@ export class CommunicationService extends BaseService {
         type: "inline",
         inlineKeyboard: markup,
       };
+    }
+
+    if (render.afterDelay) {
+      await sleep(render.afterDelay);
     }
   }
 

--- a/telegram-bot/services/keyboard.service.ts
+++ b/telegram-bot/services/keyboard.service.ts
@@ -19,8 +19,13 @@ export class KeyboardService extends BaseService {
    * Create a new empty keyboard
    * @returns
    */
-  public empty() {
-    return new Keyboard().oneTime();
+  public empty(
+    options: { isOneTime: boolean; isPersistent: boolean; isResized: boolean } =
+      { isOneTime: true, isPersistent: false, isResized: true },
+  ) {
+    return new Keyboard().oneTime(options.isOneTime).persistent(
+      options.isPersistent,
+    ).resized(options.isResized);
   }
 
   /**

--- a/telegram-bot/types/render-base.ts
+++ b/telegram-bot/types/render-base.ts
@@ -1,6 +1,10 @@
 import type { ParsedResponseType, RenderType } from "../enums/index.ts";
 import type { ReplayCondition } from "./index.ts";
-import type { InlineKeyboard, Keyboard } from "../deps/index.ts";
+import type {
+  InlineKeyboard,
+  Keyboard,
+  LinkPreviewOptions,
+} from "../deps/index.ts";
 
 export interface RenderBase {
   /**
@@ -42,4 +46,16 @@ export interface RenderBase {
    * The type in which the response should be parsed.
    */
   parseType: ParsedResponseType;
+
+  /**
+   * The delay in milliseconds before the message is sent.
+   */
+  beforeDelay?: number;
+
+  /**
+   * The delay in milliseconds after the message is sent.
+   */
+  afterDelay?: number;
+
+  linkPreview?: LinkPreviewOptions;
 }

--- a/telegram-bot/utils/index.ts
+++ b/telegram-bot/utils/index.ts
@@ -8,6 +8,7 @@ export * from "./html.ts";
 export * from "./markdown.ts";
 export * from "./number.ts";
 export * from "./object.ts";
+export * from "./promise.ts";
 export * from "./string.ts";
 export * from "./telegram.ts";
 export * from "./url.ts";

--- a/telegram-bot/utils/promise.ts
+++ b/telegram-bot/utils/promise.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
This is part of the user feedback, after the thank you message is rendered, a delay should be added before the next callouts are listed.

## Changes
* New Renderer properties `afterDelay` and `beforeDelay` for a delay after and before the message is sent
* Wait 3000 milliseconds after the thank you message (and before the list callout message) is send
* Update beabee-common and corresponding changes to the interface names
* Some cleanups
