### PR TITLE
feat(start-with-callout): Start directly with a callout

### DIFF
--- a/beabee-client/src/api/callout-client.ts
+++ b/beabee-client/src/api/callout-client.ts
@@ -42,16 +42,16 @@ export class CalloutClient extends BaseClient {
 
   /**
    * Get a callout
-   * @param slug The slug of the callout to get
+   * @param slugOrId The slug or id of the callout to get
    * @param _with The relations to include
    * @returns The callout
    */
   async get<With extends GetCalloutWith = void>(
-    slug: string,
+    slugOrId: string,
     _with?: readonly With[],
   ) {
     const { data } = await this.fetch.get<Serial<GetCalloutDataWith<With>>>(
-      `/${slug}`,
+      `/${slugOrId}`,
       { with: _with },
     );
     return this.deserialize(data);

--- a/telegram-bot/commands/show.command.ts
+++ b/telegram-bot/commands/show.command.ts
@@ -35,16 +35,16 @@ export class ShowCommand extends BaseCommand {
   }
 
   // Handle the /show command
-  async action(ctx: AppContext) {
-    let successful = await this.checkAction(ctx);
-    if (!successful) {
+  async action(ctx: AppContext, forceSlug?: string) {
+    let successful = await this.checkAction(ctx, forceSlug !== undefined);
+    if (!forceSlug && !successful) {
       return false;
     }
 
     // Get the slug from the `/show slug` message text
-    const slug = ctx.message?.text?.split(" ")[1]; // Alternatively, use ctx.match
+    const slug = forceSlug ?? ctx.match;
 
-    if (!slug) {
+    if (typeof slug !== "string") {
       await ctx.reply("Please specify a callout slug. E.g. `/show my-callout`");
       successful = false;
       return successful;

--- a/telegram-bot/constants/index.ts
+++ b/telegram-bot/constants/index.ts
@@ -1,4 +1,5 @@
 export * from "./characters.ts";
 export * from "./events.ts";
 export * from "./html.ts";
+export * from "./payloads.ts";
 export * from "./render.ts";

--- a/telegram-bot/constants/payloads.ts
+++ b/telegram-bot/constants/payloads.ts
@@ -1,0 +1,1 @@
+export const START_CALLOUT_PREFIX = "c_";


### PR DESCRIPTION
I have implemented the following format to start directly with a callout:

```
https://t.me/<bot-name>?start=c_<callout-slug>
```

Parameters can be [only passed to the `start` command](https://core.telegram.org/api/links#bot-links), so I decided to use a prefix `c_` in case we want to use other start parameters in the future.

Another limitation is that start parameters can only have up to 64 base64url characters, so long slugs could be a problem